### PR TITLE
Fix Load More button to show more contacts

### DIFF
--- a/src/main/scala/com/rockthejvm/views/ContactsView.scala
+++ b/src/main/scala/com/rockthejvm/views/ContactsView.scala
@@ -122,25 +122,30 @@ object ContactsView {
                 )
               )
             ),
+          ),
+          tr(
+            td(
+              colspan := "7",
+              div(
+                style := "display: flex; justify-content: space-between",
+                button(
+                  style := "width: 160px",
+                  HtmxAttributes.get(s"/contacts?page=${page}&q=${searchTerm}"),
+                  HtmxAttributes.target("closest tr"),
+                  HtmxAttributes.swap("outerHTML"),
+                  HtmxAttributes.select("tbody > tr"),
+                  "Load More"
+                ),
+                button(
+                  style := "width: 280px",
+                  HtmxAttributes.delete("/contacts"),
+                  HtmxAttributes.confirm("Are you sure you want to delete these contacts?"),
+                  HtmxAttributes.target("body"),
+                  "Delete Selected Contacts"
+                )
+              )
+            )
           )
-        )
-      ),
-      div(
-        style := "display: flex; justify-content: space-between",
-        button(
-          style := "width: 160px",
-          HtmxAttributes.get(s"/contacts?page=${page}&q=${searchTerm}"),
-          HtmxAttributes.target("closest tr"),
-          HtmxAttributes.swap("outerHTML"),
-          HtmxAttributes.select("tbody > tr"),
-          "Load More"
-        ),
-        button(
-          style := "width: 280px",
-          HtmxAttributes.delete("/contacts"),
-          HtmxAttributes.confirm("Are you sure you want to delete these contacts?"),
-          HtmxAttributes.target("body"),
-          "Delete Selected Contacts"
         )
       )
     ),


### PR DESCRIPTION
## Summary

Moving **Load More** and **Delete Selected Contacts** into a new last `<tr>` row ensures the `page` variable updates on each click, allowing contacts to render correctly.

## Steps to Reproduce

1. Add an 11th contact.  
2. Click **Load More**.

## Expected

The table expands to show contact #11 immediately upon clicking **Load More**.

## Actual

The table remains at 10 rows even though the total count has increased.

## Attached Videos

- **Video 1 (before):** Load More stuck at 10 contacts

https://github.com/user-attachments/assets/05a00d14-930a-4d2b-bc94-cbf3efe31caf

- **Video 2 (after):** 11th contact appears correctly

https://github.com/user-attachments/assets/725a9296-7625-4b48-90d7-62ae734a376a

## Notes

Buttons were relocated to update the `page` variable dynamically. Inspired by HTMX’s “Click to Load” example from the official docs.